### PR TITLE
Change logic of whether or not to run init mode

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -32,7 +32,7 @@ for f in /docker-entrypoint-initdb.d/*; do
 done
 
 
-if [[ ! -d /db/db/diffs ]] ; then
+if [[ ! -d /db/diffs ]] ; then
     if [[ "$OVERPASS_MODE" = "clone" ]]; then
         mkdir -p /db/db \
         && /app/bin/download_clone.sh --db-dir=/db/db --source=http://dev.overpass-api.de/api_drolbr/ --meta="${OVERPASS_META}" \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -32,7 +32,7 @@ for f in /docker-entrypoint-initdb.d/*; do
 done
 
 
-if [[ ! -d /db/db ]] ; then
+if [[ ! -d /db/db/diffs ]] ; then
     if [[ "$OVERPASS_MODE" = "clone" ]]; then
         mkdir -p /db/db \
         && /app/bin/download_clone.sh --db-dir=/db/db --source=http://dev.overpass-api.de/api_drolbr/ --meta="${OVERPASS_META}" \


### PR DESCRIPTION
Why:
* If init mode starts, only gets partway through the download process, then Something Happens™ to cause the docker container to stop, then we cannot resume initialization
* The underlying `download_clone.sh` script does support download resuming

How:
* Tack on `/diffs` to the end of the `/db/db` check

Related Links:
* https://github.com/wiktorn/Overpass-API/issues/18