### PR TITLE
Ignore corruption in changes.osm

### DIFF
--- a/bin/update_overpass.sh
+++ b/bin/update_overpass.sh
@@ -56,7 +56,7 @@ fi
 
         # if DIFF_FILE is non-empty, try to process it
         if [[ -s ${DIFF_FILE} ]] ; then
-            VERSION=$(osmium fileinfo -e -g data.timestamp.last "${DIFF_FILE}")
+            VERSION=$(osmium fileinfo -e -g data.timestamp.last "${DIFF_FILE}" || echo "")
             if [[ ! -z "${VERSION// }" ]] ; then
               echo /app/bin/update_database --version="${VERSION}" "${UPDATE_ARGS[@]}"
               cat "${DIFF_FILE}" | /app/bin/update_database --version="${VERSION}" "${UPDATE_ARGS[@]}"


### PR DESCRIPTION
If changes.osm is corrupt, `osmium fileinfo` will return exit code 1 and the script will terminate, but the diff file will still exist. As a result, the changes will never be applied. This small change simply returns "" if the timestamp can't be read, and the file will be skipped.