### PR TITLE
Fix healtcheck when proxies are being used

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ docker run \
 Using following environment variable:
 ```
 -e OVERPASS_HEALTHCHECK='
-  OVERPASS_RESPONSE=$(curl -s "http://localhost/api/interpreter?data=\[out:json\];node(1);out;" | jq -r .osm3s.timestamp_osm_base)
+  OVERPASS_RESPONSE=$(curl --noproxy "*" -s "http://localhost/api/interpreter?data=\[out:json\];node(1);out;" | jq -r .osm3s.timestamp_osm_base)
   OVERPASS_DATE=$(date -d "$OVERPASS_RESPONSE" +%s)
   TWO_DAYS_AGO=$(($(date +%s) - 2*86400)) ;
   if [ ${OVERPASS_DATE} -lt ${TWO_DAYS_AGO} ] ; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,5 +22,5 @@ services:
       - OVERPASS_UPDATE_SLEEP=3600
       - OVERPASS_USE_AREAS=false
     healthcheck:
-      test: ["CMD-SHELL", "curl --noproxy "*" -qf 'http://localhost/api/interpreter?data=\[out:json\];node(1);out;' | jq '.generator' |grep -q Overpass || exit 1"]
+      test: ["CMD-SHELL", "curl --noproxy '*' -qf 'http://localhost/api/interpreter?data=\[out:json\];node(1);out;' | jq '.generator' |grep -q Overpass || exit 1"]
       start_period: 48h

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,5 +22,5 @@ services:
       - OVERPASS_UPDATE_SLEEP=3600
       - OVERPASS_USE_AREAS=false
     healthcheck:
-      test: ["CMD-SHELL", "curl -qf 'http://localhost/api/interpreter?data=\[out:json\];node(1);out;' | jq '.generator' |grep -q Overpass || exit 1"]
+      test: ["CMD-SHELL", "curl --noproxy "*" -qf 'http://localhost/api/interpreter?data=\[out:json\];node(1);out;' | jq '.generator' |grep -q Overpass || exit 1"]
       start_period: 48h

--- a/docker-healthcheck.sh
+++ b/docker-healthcheck.sh
@@ -2,6 +2,6 @@
 
 set -e -o pipefail
 
-OVERPASS_HEALTHCHECK=${OVERPASS_HEALTHCHECK:-'curl -qf "http://localhost/api/interpreter?data=\[out:json\];node(1);out;" | jq ".generator" |grep -q Overpass || exit 1'}
+OVERPASS_HEALTHCHECK=${OVERPASS_HEALTHCHECK:-'curl --noproxy "*" -qf "http://localhost/api/interpreter?data=\[out:json\];node(1);out;" | jq ".generator" |grep -q Overpass || exit 1'}
 
 eval "${OVERPASS_HEALTHCHECK}"


### PR DESCRIPTION
curl will respect environment variables like http_proxy even for requests to localhost.
Proxies have to be disabled for health checks on localhost, in case NO_PROXY=localhost is not set