### PR TITLE
Remove ineffective argument from sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Data will be stored in `/big/docker/overpass_clone_db/`  on the host machine and
 
 ```
 docker run \
-  -e OVERPASS_META=yes \
   -e OVERPASS_MODE=clone \
   -e OVERPASS_DIFF_URL=https://planet.openstreetmap.org/replication/minute/ \
   -v /big/docker/overpass_clone_db/:/db \


### PR DESCRIPTION
Based on the documentation of the individual env vars, `OVERPASS_META` only applies on `init` mode. Since this docker run example is using the `clone` mode the `OVERPASS_META` is ineffective and only makes the sample more complex and confusing.