### PR TITLE
Fix message with actual diff file name

### DIFF
--- a/bin/update_overpass.sh
+++ b/bin/update_overpass.sh
@@ -52,7 +52,7 @@ fi
 				set -e
 			fi
 		else
-			echo "/db/diffs/changes.osm exists. Trying to apply again."
+			echo "${DIFF_FILE} exists. Trying to apply again."
 		fi
 
 		# if DIFF_FILE is non-empty, try to process it


### PR DESCRIPTION
The message said "/db/diffs/changes.osm exists", but the file name is in
$DIFF_FILE.
