### PR TITLE
Use cp instead of curl for copying local files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The following enviroment variables can be used to customize the setup:
 
 * `OVERPASS_MODE` - takes the value of either `init` or `clone`. Defaults to `clone`.
 * `OVERPASS_META` - (`init` mode only) `yes`, `no` or `attic` - passed to Overpass as `--meta` or `--keep-attic`.
-* `OVERPASS_PLANET_URL` - (`init` mode only) url to a "planet" file (e.g. https://planet.openstreetmap.org/planet/planet-latest.osm.bz2)
+* `OVERPASS_PLANET_URL` - (`init` mode only) url/path to a "planet" file (e.g. https://planet.openstreetmap.org/planet/planet-latest.osm.bz2 or /db/planet-latest.osm.bz2)
 * `OVERPASS_CLONE_SOURCE` - (`clone` mode only) the url to clone a copy of Overpass from. Defaults to https://dev.overpass-api.de/api_drolbr/, which uses minute diffs.
 * `OVERPASS_DIFF_URL` - url to a diff directory for updating the instance (e.g. https://planet.openstreetmap.org/replication/minute/).
 * `OVERPASS_COMPRESSION` - (`init` mode only) takes values of `no`, `gz` or `lz4`. Specifies compression mode of the Overpass database. Defaults to `gz`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,10 +14,14 @@ services:
     volumes:
       # use a docker managed volume
       - overpass-db:/db
+      # If you want to mount your osm file as volume
+      # - ./monaco-latest.osm.bz2:/db/monaco-latest.osm.bz2
     environment:
       - OVERPASS_META=no
       - OVERPASS_MODE=init
       - OVERPASS_PLANET_URL=http://download.geofabrik.de/europe/monaco-latest.osm.bz2
+      # If you want to load your own file directly
+      # - OVERPASS_PLANET_URL=/db/monaco-latest.osm.bz2
       - OVERPASS_DIFF_URL=http://download.openstreetmap.fr/replication/europe/monaco/minute/
       - OVERPASS_UPDATE_SLEEP=3600
       - OVERPASS_USE_AREAS=false

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -76,10 +76,12 @@ if [[ ! -f /db/init_done ]]; then
 		if [[ "$OVERPASS_PLANET_URL" =~ ^file:// ]] || [[ -f $OVERPASS_PLANET_URL ]]; then
 			if [[ "$OVERPASS_PLANET_URL" =~ ^file:// ]]; then
 				#Remove the "file://" prefix from the string
-				OVERPASS_PLANET_FILE="{OVERPASS_PLANET_URL#file://}"
+				OVERPASS_PLANET_FILE="${OVERPASS_PLANET_URL#file://}"
+			else
+				OVERPASS_PLANET_FILE=$OVERPASS_PLANET_URL
 			fi
 			#Copy the file to the correct position
-			mv OVERPASS_PLANET_FILE /db/planet.osm.bz2
+			cp "$OVERPASS_PLANET_FILE" /db/planet.osm.bz2
 			#Mock the curl status code for further procedure
 			CURL_STATUS_CODE=000
 		else


### PR DESCRIPTION
[Since the geofabrik stopped producing bz2 extracts](https://download.geofabrik.de/bz2.html), it is necessary to convert the files from the osm.pbf to the osm.bz2 format. Some people (myself included) want to do this before starting the docker container and mounting the file into the container.

This leads to the "problem" of using curl to copy files locally, which is not very fast.
```bash
arne@desktop:~$ time curl file:///home/arne/europe-latest.osm.pbf -o /tmp/europe-latest.osm.pbf
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 29.7G  100 29.7G    0     0   146M      0  0:03:27  0:03:27 --:--:-- 54.2M

real    3m28.067s
user    0m1.024s
sys     0m32.632s
arne@desktop:~$ time cp europe-latest.osm.pbf /tmp/europe-latest.osm.pbf

real    3m3.196s
user    0m0.070s
sys     0m28.234s
```

This PR handles the request by checking if it is a local file ([using -f](https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Bash-Conditional-Expressions)). For compatibility with older versions, it also checks if the string starts with file:// and removes it from the string.