### PR TITLE
Feature: Allow preprocessing of diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The following enviroment variables can be used to customize the setup:
 * `OVERPASS_UPDATE_SLEEP` - integer, the delay between updates (seconds).
 * `OVERPASS_COOKIE_JAR_CONTENTS` - cookie-jar compatible content to be used when fetching planet.osm files and updates.
 * `OVERPASS_PLANET_PREPROCESS` - commands to be run before passing the planet.osm file to `update_database`, e.g. conversion from pbf to osm.bz2 using osmium.
+* `OVERPASS_DIFF_PREPROCESS` - commands to be run before passing the diff.osc file to `update_database`, e.g. extracting geo specific regions
 * `USE_OAUTH_COOKIE_CLIENT` - set to `yes` if you want to use oauth_cookie_client to update cookies before each update. Settings are read from /secrets/oauth-settings.json. Read the documentation [here](https://github.com/geofabrik/sendfile_osm_oauth_protector/blob/master/doc/client.md).
 * `OVERPASS_FASTCGI_PROCESSES` - number of fcgiwarp processes. Defaults to 4. Use higher values if you notice performance problems.
 * `OVERPASS_RATE_LIMIT` - set the maximum allowed number of concurrent accesses from a single IP address.

--- a/bin/update_overpass.sh
+++ b/bin/update_overpass.sh
@@ -8,6 +8,7 @@ DIFF_FILE=/db/diffs/changes.osc
 OVERPASS_META=${OVERPASS_META:-no}
 OVERPASS_COMPRESSION=${OVERPASS_COMPRESSION:-gz}
 OVERPASS_FLUSH_SIZE=${OVERPASS_FLUSH_SIZE:-16}
+OVERPASS_DIFF_PREPROCESS=${OVERPASS_DIFF_PREPROCESS:-}
 
 if [ -z "$OVERPASS_DIFF_URL" ]; then
 	echo "No OVERPASS_DIFF_URL set. Skipping update."
@@ -59,6 +60,11 @@ fi
 		if [[ -s ${DIFF_FILE} ]]; then
 			VERSION=$(osmium fileinfo -e -g data.timestamp.last "${DIFF_FILE}" || (cp -f /db/replicate_id.backup /db/replicate_id && echo "Broken file" && cat "${DIFF_FILE}" && rm -f "${DIFF_FILE}" && exit 1))
 			if [[ -n "${VERSION// /}" ]]; then
+				#Check if an Preprocessing command exists and try to execute it
+				if [[ -n ${OVERPASS_DIFF_PREPROCESS+x} ]]; then
+					echo "Running preprocessing command: ${OVERPASS_DIFF_PREPROCESS}"
+					eval "${OVERPASS_DIFF_PREPROCESS}"
+				fi
 				echo /app/bin/update_from_dir --osc-dir="$(dirname ${DIFF_FILE})" --version="${VERSION}" "${UPDATE_ARGS[@]}"
 				/app/bin/update_from_dir --osc-dir="$(dirname ${DIFF_FILE})" --version="${VERSION}" "${UPDATE_ARGS[@]}"
 			else


### PR DESCRIPTION
Allows to run commands for each diff before processing it. Similar logic like `OVERPASS_PLANET_PREPROCESS`. Can be invoked by adding  -e `OVERPASS_DIFF_PREPROCESS=YOUR COMMAND HERE`.

HowTo test:
```bash
git clone git@github.com:arnesetzer/Overpass-API.git
git checkout feat/diff_preprocess
docker build -f 0.7.62.5/Dockerfile -t yourDockerTag/overpass-diff
#I used nordrhein-westfalen germany for testing, since it also small but has more frequent updates than monaco.
docker run \
  -e OVERPASS_META=yes \
  -e OVERPASS_MODE=init \
  -e OVERPASS_PLANET_URL=file:///db/nordrhein-westfalen-latest.osm.pbf
  -e OVERPASS_PLANET_PREPROCESS=osmium cat -F pbf /db/planet.osm.bz2 -O -o /db/planet.osm.bz2
  -e OVERPASS_DIFF_URL=http://download.openstreetmap.fr/replication/europe/germany/nordrhein_westfalen/minute/
  -e OVERPASS_DIFF_PREPROCESS=echo Hi #Didn't found any useful command to run
  -e OVERPASS_STOP_AFTER_INIT=false
  -p 12345:80 \
  -i -t \
  --name overpass_diff_test wiktorn/overpass-api
```
After this you should see
```bash
overpass_diff_test | Running preprocessing command: echo Hi
overpass_diff_test | Hi
```
in the log.

Hopefully resolves #67 