### PR TITLE
fix: Fix invalid docker compose syntax for healthcheck by using curl -g

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ version: '3.8'
 services:
   overpass:
     # specify the image here
-    image: wiktorn/overpass-api:0.7.62
+    image: wiktorn/overpass-api:0.7.56.9
     container_name: overpass
     # uncomment if you want to build the image yourself
     # build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,5 +22,5 @@ services:
       - OVERPASS_UPDATE_SLEEP=3600
       - OVERPASS_USE_AREAS=false
     healthcheck:
-      test: ["CMD-SHELL", "curl --noproxy '*' -qf 'http://localhost/api/interpreter?data=\[out:json\];node(1);out;' | jq '.generator' |grep -q Overpass || exit 1"]
+      test: ["CMD-SHELL", "curl --noproxy '*' -qfg 'http://localhost/api/interpreter?data=[out:json];node(1);out;' | jq '.generator' |grep -q Overpass || exit 1"]
       start_period: 48h

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ version: '3.8'
 services:
   overpass:
     # specify the image here
-    image: wiktorn/overpass-api:0.7.56.9
+    image: wiktorn/overpass-api:0.7.62
     container_name: overpass
     # uncomment if you want to build the image yourself
     # build: .
@@ -22,5 +22,5 @@ services:
       - OVERPASS_UPDATE_SLEEP=3600
       - OVERPASS_USE_AREAS=false
     healthcheck:
-      test: ["CMD-SHELL", "curl --noproxy '*' -qfg 'http://localhost/api/interpreter?data=[out:json];node(1);out;' | jq '.generator' |grep -q Overpass || exit 1"]
+      test: curl --noproxy '*' -qfg 'http://localhost/api/interpreter?data=[out:json];node(1);out;' | jq '.generator' |grep -q Overpass || exit 1
       start_period: 48h


### PR DESCRIPTION
Two small changes:

1. Since the current health check command results in `[invalid docker ](yaml: line 25: found unknown escape character)` I changed it to use [-g](https://curl.se/docs/manpage.html#-g) which disables curl to interpret `{}[]` and therefore they do not need to be escaped which resolves the docker compose error message.
2. I also simplified the command [since `test: ["CMD-SHELL", "curl -f http://localhost || exit 1"]` and `test: curl -f https://localhost || exit 1` are equivalent](https://docs.docker.com/reference/compose-file/services/#healthcheck), I do not see any reason to complicate the syntax more than necessary. 