### PR TITLE
Handle empty `OVERPASS_PLANET_PREPROCESS`

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -82,7 +82,7 @@ if [[ ! -f /db/init_done ]]; then
 		# for `file:///` scheme curl returns `000` HTTP status code
 		if [[ $CURL_STATUS_CODE = "200" || $CURL_STATUS_CODE = "000" ]]; then
 			(
-				if [[ -n "${OVERPASS_PLANET_PREPROCESS+x}" ]]; then
+				if [[ -n "${OVERPASS_PLANET_PREPROCESS:+x}" ]]; then
 					echo "Running preprocessing command: ${OVERPASS_PLANET_PREPROCESS}"
 					eval "${OVERPASS_PLANET_PREPROCESS}"
 				fi &&


### PR DESCRIPTION
An empty `OVERPASS_PLANET_PREPROCESS` should be treated the same as if it was not set.

Setting an empty variable can occur with the following `docker-compose.yml` definition:

```yml
    environment:
      OVERPASS_PLANET_PREPROCESS: ${OVERPASS_PLANET_PREPROCESS:-}
```

which, in turn, allows the environment variable to be optionally set in Github Actions or any other way of invoking the overpass docker image using `docker compose`.

This PR would also avoid having the following puzzling line in the `docker compose logs` output:
```
overpass-1  | Running preprocessing command: 
```