### PR TITLE
fix(entrypoint): honor STOP_AFTER_INIT if DB already initialized

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -54,11 +54,11 @@ setup_cookie_jar() {
 	chown -R overpass:overpass /db/cookie.jar /db/changes.log /db/diffs
 }
 
-if [[ ! -f /db/init_done ]]; then
-	initialize_db_dir
-	setup_cookie_jar
 
-	if [[ "$OVERPASS_MODE" = "clone" ]]; then
+if [[ "$OVERPASS_MODE" = "clone" ]]; then
+	if [[ ! -f /db/init_done ]]; then
+		initialize_db_dir
+		setup_cookie_jar
 		(
 			mkdir -p /db/db &&
 				/app/bin/download_clone.sh --db-dir=/db/db --source="${OVERPASS_CLONE_SOURCE}" --meta="${OVERPASS_META}" &&
@@ -76,9 +76,16 @@ if [[ ! -f /db/init_done ]]; then
 			echo "Overpass container initialization complete. Exiting."
 			exit 0
 		fi
+	else
+		echo "Database directory already initialized. Skipping clone."
 	fi
+fi
 
-	if [[ "$OVERPASS_MODE" = "init" ]]; then
+if [[ "$OVERPASS_MODE" = "init" ]]; then
+	if [[ ! -f /db/init_done ]]; then
+		initialize_db_dir
+		setup_cookie_jar
+		
 		CURL_STATUS_CODE=$(curl -L -b /db/cookie.jar -o /db/planet.osm.bz2 -w "%{http_code}" "${OVERPASS_PLANET_URL}")
 		# try again until it's allowed
 		while [ "$CURL_STATUS_CODE" = "429" ]; do

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -71,13 +71,6 @@ if [[ "$OVERPASS_MODE" = "clone" ]]; then
 			exit 1
 		)
 	fi
-
-	if [[ "${OVERPASS_STOP_AFTER_INIT}" == "false" ]]; then
-		echo "Overpass container ready to receive requests"
-	else
-		echo "Overpass container initialization complete. Exiting."
-		exit 0
-	fi
 fi
 
 if [[ "$OVERPASS_MODE" = "init" ]]; then
@@ -125,7 +118,9 @@ if [[ "$OVERPASS_MODE" = "init" ]]; then
 			exit 1
 		fi
 	fi
+fi
 
+if [[ "$OVERPASS_MODE" = "init" || "$OVERPASS_MODE" = "clone" ]]; then
 	if [[ "${OVERPASS_STOP_AFTER_INIT}" == "false" ]]; then
 		echo "Overpass container ready to receive requests"
 	else

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -70,14 +70,13 @@ if [[ "$OVERPASS_MODE" = "clone" ]]; then
 			echo "Failed to clone overpass repository"
 			exit 1
 		)
-		if [[ "${OVERPASS_STOP_AFTER_INIT}" == "false" ]]; then
-			echo "Overpass container ready to receive requests"
-		else
-			echo "Overpass container initialization complete. Exiting."
-			exit 0
-		fi
+	fi
+
+	if [[ "${OVERPASS_STOP_AFTER_INIT}" == "false" ]]; then
+		echo "Overpass container ready to receive requests"
 	else
-		echo "Database directory already initialized. Skipping clone."
+		echo "Overpass container initialization complete. Exiting."
+		exit 0
 	fi
 fi
 
@@ -116,12 +115,6 @@ if [[ "$OVERPASS_MODE" = "init" ]]; then
 				echo "Failed to process planet file"
 				exit 1
 			)
-			if [[ "${OVERPASS_STOP_AFTER_INIT}" == "false" ]]; then
-				echo "Overpass container ready to receive requests"
-			else
-				echo "Overpass container initialization complete. Exiting."
-				exit 0
-			fi
 		elif [[ $CURL_STATUS_CODE = "403" ]]; then
 			echo "Access denied when downloading planet file. Check your OVERPASS_PLANET_URL and OVERPASS_COOKIE_JAR_CONTENTS or USE_OAUTH_COOKIE_CLIENT"
 			cat /db/cookie.jar
@@ -131,6 +124,13 @@ if [[ "$OVERPASS_MODE" = "init" ]]; then
 			cat /db/planet.osm.bz2
 			exit 1
 		fi
+	fi
+
+	if [[ "${OVERPASS_STOP_AFTER_INIT}" == "false" ]]; then
+		echo "Overpass container ready to receive requests"
+	else
+		echo "Overpass container initialization complete. Exiting."
+		exit 0
 	fi
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -36,11 +36,13 @@ for f in /docker-entrypoint-initdb.d/*; do
 	echo
 done
 
-if [[ ! -f /db/init_done ]]; then
+initialize_db_dir() {
 	echo "No database directory. Initializing"
 	touch /db/changes.log
 	mkdir -p /db/diffs
+}
 
+setup_cookie_jar() {
 	if [[ "${USE_OAUTH_COOKIE_CLIENT}" = "yes" ]]; then
 		/app/venv/bin/python /app/bin/oauth_cookie_client.py -o /db/cookie.jar -s /secrets/oauth-settings.json --format netscape
 		# necessary to add newline at the end as oauth_cookie_client doesn't do that
@@ -50,6 +52,11 @@ if [[ ! -f /db/init_done ]]; then
 		echo "${OVERPASS_COOKIE_JAR_CONTENTS}" >>/db/cookie.jar
 	fi
 	chown -R overpass:overpass /db/cookie.jar /db/changes.log /db/diffs
+}
+
+if [[ ! -f /db/init_done ]]; then
+	initialize_db_dir
+	setup_cookie_jar
 
 	if [[ "$OVERPASS_MODE" = "clone" ]]; then
 		(


### PR DESCRIPTION
**Description**:
This PR ensures `OVERPASS_STOP_AFTER_INIT` is applied consistently in both init and clone modes.

Before, the flag was only checked when the database was freshly created. If /db/init_done already existed, the container ignored the flag and continued running, which broke automation workflows relying on idempotent init steps. Common Dev/Ops patterns separates the initialization and the serving stages.

**Changes in this PR:**
- Refactored init/clone logic into helper functions early on
- Started to re-arrange flow for better readability.
- Finally fixed logic so that OVERPASS_STOP_AFTER_INIT is always evaluated, even if the database was already initialized.

**Result**: containers in init or clone mode now exit consistently when OVERPASS_STOP_AFTER_INIT=true, regardless of whether initialization work was performed.