### PR TITLE
fix: Create workaround for hard shutdown and orphaned area file.

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -36,6 +36,12 @@ for f in /docker-entrypoint-initdb.d/*; do
 	echo
 done
 
+# deleting areas file if present. Otherwise the link to /db/db/osm3s_vX.X.X_areas will not be created and the area is not availible.
+if [ -f /dev/shm/osm3s_areas ]; then
+	echo "Found orphaned /dev/shm/osm3s_areas file. Deleting it."
+	rm /dev/shm/osm3s_areas
+fi
+
 if [[ ! -f /db/init_done ]]; then
 	echo "No database directory. Initializing"
 	touch /db/changes.log


### PR DESCRIPTION
Closes #154 

It's basically just a quick workaround to fix the behaviour whereby the shared memory (`/dev/shm`), for some reason (Docker), is not deleted on a hard shutdown, and the `/db/db/osm3s_areas` file is not created on reboot since the `/dev/shm/osm3s_areas` file exists. [There is also a script that performs the same function in the non-dockerised Overpass-API instance](https://github.com/drolbr/Overpass-API/blob/a0db4f392f744d5e1304331edbf542ef6d6ce2fa/debian/overpass#L76).