### PR TITLE
Publish multi-arch images automatically with `docker/github-builder`

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,6 +24,8 @@ jobs:
       push: true
       platforms: linux/amd64,linux/arm64
       build-args: OVERPASS_VERSION=${{ github.event.release.tag_name || inputs.overpass_version }}
+      cache: true
+      cache-mode: max
       meta-images: ${{ vars.DOCKERHUB_USERNAME }}/overpass-api
       meta-tags: type=semver,pattern={{version}}
     secrets:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,6 +3,12 @@ name: Publish multi-arch Docker image
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      overpass_version:
+        description: 'Version number to build (e.g. 0.7.62)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -17,7 +23,7 @@ jobs:
       output: image
       push: true
       platforms: linux/amd64,linux/arm64
-      build-args: OVERPASS_VERSION=${{ github.event.release.tag_name }}
+      build-args: OVERPASS_VERSION=${{ github.event.release.tag_name || inputs.overpass_version }}
       meta-images: ${{ vars.DOCKERHUB_USERNAME }}/overpass-api
       meta-tags: type=semver,pattern={{version}}
     secrets:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,27 @@
+name: Publish multi-arch Docker image
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: docker/github-builder/.github/workflows/build.yml@v1
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      output: image
+      push: true
+      platforms: linux/amd64,linux/arm64
+      build-args: OVERPASS_VERSION=${{ github.event.release.tag_name }}
+      meta-images: ${{ vars.DOCKERHUB_USERNAME }}/overpass-api
+      meta-tags: type=semver,pattern={{version}}
+    secrets:
+      registry-auths: |
+        - registry: docker.io
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ RUN apt-get update \
         zlib1g \
         zlib1g-dev
 
-ADD http://dev.overpass-api.de/releases/osm-3s_v{version}.tar.gz /app/src.tar.gz
+ARG OVERPASS_VERSION
+ADD http://dev.overpass-api.de/releases/osm-3s_v${OVERPASS_VERSION}.tar.gz /app/src.tar.gz
 
 RUN  mkdir -p /app/src \
     && cd /app/src \
@@ -91,9 +92,9 @@ COPY docker-entrypoint.sh docker-healthcheck.sh /app/
 RUN chmod a+rx /app/docker-entrypoint.sh /app/bin/update_overpass.sh /app/bin/rules_loop.sh /app/bin/dispatcher_start.sh \
     /app/bin/oauth_cookie_client.py /app/bin/start_fcgiwarp.sh
 
-ENV OVERPASS_RULES_LOAD=${{OVERPASS_RULES_LOAD:-1}}
-ENV OVERPASS_USE_AREAS=${{OVERPASS_USE_AREAS:-true}}
-ENV OVERPASS_ALLOW_DUPLICATE_QUERIES=${{OVERPASS_ALLOW_DUPLICATE_QUERIES:-no}}
+ENV OVERPASS_RULES_LOAD=${OVERPASS_RULES_LOAD:-1}
+ENV OVERPASS_USE_AREAS=${OVERPASS_USE_AREAS:-true}
+ENV OVERPASS_ALLOW_DUPLICATE_QUERIES=${OVERPASS_ALLOW_DUPLICATE_QUERIES:-no}
 
 EXPOSE 80
 

--- a/build.sh
+++ b/build.sh
@@ -25,8 +25,8 @@ case "$1" in
 "$1")
 	echo "Invalid argument $1"
 	echo "Valid arguments:"
-	echo "$0 build - to build docker images"
-	echo "$0 push - to push built images to docker hub"
+	echo "$0 build - to build Docker images"
+	echo "$0 push - to push built images to Docker Hub"
 	exit 1
 	;;
 esac

--- a/build.sh
+++ b/build.sh
@@ -2,23 +2,29 @@
 
 set -e
 
+IMAGE=wiktorn/overpass-api
+
 case "$1" in
 "build")
-	python update.py
+	versions=$(python update.py)
 
-	# docker build
-	find . -maxdepth 1 -type d -name '0.*' -exec sh -c 'docker build -t wiktorn/overpass-api:$(basename "$1") -f "$1"/Dockerfile .' sh {} \;
+	for version in $versions; do
+		docker build --build-arg "OVERPASS_VERSION=${version}" -t "${IMAGE}:${version}" .
+	done
 
-	# docker tag
-	while IFS= read -r -d '' file; do
-		docker tag "wiktorn/overpass-api:$(basename "$file")" wiktorn/overpass-api:latest
-	done < <(find . -maxdepth 1 -type d -regex '\./[0-9]\.[0-9]\.[0-9]*' -print0 | sort -nz | tail -z -n 1)
+	latest=$(echo "$versions" | sort -V | tail -n 1)
+	docker tag "${IMAGE}:${latest}" "${IMAGE}:latest"
 	;;
+
 "push")
-	# docker push
-	find . -maxdepth 1 -type d -name '0.*' -exec sh -c 'docker push "wiktorn/overpass-api:$(basename "$1")"' sh {} \;
-	docker push wiktorn/overpass-api:latest
+	versions=$(python update.py)
+
+	for version in $versions; do
+		docker push "${IMAGE}:${version}"
+	done
+	docker push "${IMAGE}:latest"
 	;;
+
 "$1")
 	echo "Invalid argument $1"
 	echo "Valid arguments:"

--- a/build.sh
+++ b/build.sh
@@ -3,23 +3,20 @@
 set -e
 
 IMAGE=wiktorn/overpass-api
+VERSIONS=$(python update.py)
 
 case "$1" in
 "build")
-	versions=$(python update.py)
-
-	for version in $versions; do
+	for version in $VERSIONS; do
 		docker build --build-arg "OVERPASS_VERSION=${version}" -t "${IMAGE}:${version}" .
 	done
 
-	latest=$(echo "$versions" | sort -V | tail -n 1)
+	latest=$(echo "$VERSIONS" | sort -V | tail -n 1)
 	docker tag "${IMAGE}:${latest}" "${IMAGE}:latest"
 	;;
 
 "push")
-	versions=$(python update.py)
-
-	for version in $versions; do
+	for version in $VERSIONS; do
 		docker push "${IMAGE}:${version}"
 	done
 	docker push "${IMAGE}:latest"

--- a/update.py
+++ b/update.py
@@ -1,10 +1,12 @@
 import html.parser
-import os
-import pathlib
-import shutil
 import urllib.request
 
 url = "http://dev.overpass-api.de/releases/"
+skip_prefixes = (
+    '0.6', 'eta', '0.7.1', '0.7.2', '0.7.3', '0.7.4', '0.7.50', '0.7.52',
+    '0.7.54.11',  # invalid CRC in archive
+    '0.7.51',  # no autoconf
+)
 
 
 class VersionFinder(html.parser.HTMLParser):
@@ -23,31 +25,19 @@ class VersionFinder(html.parser.HTMLParser):
                 self.versions.append(version)
 
 
-def main():
+def versions_to_build():
     parser = VersionFinder()
     response = urllib.request.urlopen(url)
     data = response.read().decode(response.headers.get_content_charset())
     parser.feed(data)
-    with open("Dockerfile") as f:
-        template = f.read()
-    for ver in parser.versions:
-        if any((ver.startswith(x) for x in ('0.6', 'eta', '0.7.1', '0.7.2', '0.7.3', '0.7.4', '0.7.50', '0.7.52',
-                                            '0.7.54.11',  # invalid CRC in archive
-                                            '0.7.51',  # no autoconf
-                                            ))) or \
-                ver == '0.7':
-            # ignore old releases
-            continue
-        if os.path.exists(ver):
-            shutil.rmtree(ver)
-        os.mkdir(ver)
-        with open(pathlib.Path(ver) / "Dockerfile", "w+") as f:
-            f.write(template.replace("${OVERPASS_VERSION}", ver))
-        #for i in ("etc", "bin"):
-        #    shutil.copytree(i, pathlib.Path(ver) / i)
-        #shutil.copyfile("docker-entrypoint.sh", pathlib.Path(ver) / "docker-entrypoint.sh")
-        #shutil.copyfile("requirements.txt", pathlib.Path(ver) / "requirements.txt")
+
+    return [
+        version for version in parser.versions
+        if version != '0.7'
+        and not any(version.startswith(skip_prefix) for skip_prefix in skip_prefixes)
+    ]
 
 
 if __name__ == '__main__':
-    main()
+    for version_to_build in versions_to_build():
+        print(version_to_build)

--- a/update.py
+++ b/update.py
@@ -28,7 +28,7 @@ def main():
     response = urllib.request.urlopen(url)
     data = response.read().decode(response.headers.get_content_charset())
     parser.feed(data)
-    with open("Dockerfile.template") as f:
+    with open("Dockerfile") as f:
         template = f.read()
     for ver in parser.versions:
         if any((ver.startswith(x) for x in ('0.6', 'eta', '0.7.1', '0.7.2', '0.7.3', '0.7.4', '0.7.50', '0.7.52',
@@ -42,7 +42,7 @@ def main():
             shutil.rmtree(ver)
         os.mkdir(ver)
         with open(pathlib.Path(ver) / "Dockerfile", "w+") as f:
-            f.write(template.format(version=ver))
+            f.write(template.replace("${OVERPASS_VERSION}", ver))
         #for i in ("etc", "bin"):
         #    shutil.copytree(i, pathlib.Path(ver) / i)
         #shutil.copyfile("docker-entrypoint.sh", pathlib.Path(ver) / "docker-entrypoint.sh")


### PR DESCRIPTION
I'd like to suggest switching from manual Docker image building and Docker Hub pushing to an automated workflow because it can also easily provide ARM64 builds on each release. (This would resolve #87.)

@wiktorn I don't know if it would fit into your workflow but the new process would require all new releases being created from now on at https://github.com/wiktorn/overpass-api/releases/new. Let me know if you like the idea of automated publishing but would prefer another trigger type!

The workflow would also use the `DOCKERHUB_TOKEN` repository secret and `DOCKERHUB_USERNAME` repository variable that have to be set manually first.

Testing would also be needed to check if the Docker Hub push succeeds this way.

Detailed changes:

- Rename `Dockerfile.template` to `Dockerfile` to make it usable for the GitHub Action
- `ARG OVERPASS_VERSION` instead of `{version}` Python field formatting
- Remove curly bracket Python format field escaping from `ENV` declarations
- Create `docker-publish.yml` which uses the new [`docker/github-builder`](https://github.com/docker/github-builder) GitHub Action that makes configuring builds fairly simple