### PR TITLE
Add `OVERPASS_MAX_SIZE` argument to set nginx max size

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The following enviroment variables can be used to customize the setup:
 * `OVERPASS_TIME` - set the maximum amount of time units (available time).
 * `OVERPASS_SPACE` - set the maximum amount of RAM (available space) in bytes.
 * `OVERPASS_MAX_TIMEOUT` - set the maximum timeout for queries (default: 1000s). Translates to send/recv timeout for fastcgi_wrap.
+* `OVERPASS_MAX_SIZE` - set the maximum size for queries (default: 10M). Translates to nginx [`client_max_body_size`](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size).
 * `OVERPASS_USE_AREAS` - if `false` initial area generation and the area updater process will be disabled. Default `true`.
 * `OVERPASS_HEALTHCHECK` - shell commands to execute to verify that image is healthy. `exit 1` in case of failures, `exit 0` when container is healthy. Default healthcheck queries overpass and verifies that there is reponse returned
 * `OVERPASS_STOP_AFTER_INIT` - if `false` the container will keep runing after init is complete. Otherwise container will be stopped after initialization process is complete. Default `true`

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following enviroment variables can be used to customize the setup:
 * `OVERPASS_TIME` - set the maximum amount of time units (available time).
 * `OVERPASS_SPACE` - set the maximum amount of RAM (available space) in bytes.
 * `OVERPASS_MAX_TIMEOUT` - set the maximum timeout for queries (default: 1000s). Translates to send/recv timeout for fastcgi_wrap.
-* `OVERPASS_MAX_SIZE` - set the maximum size for queries (default: 10M). Translates to nginx [`client_max_body_size`](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size).
+* `OVERPASS_MAX_SIZE` - set the maximum size for queries (default: 1M). Translates to nginx [`client_max_body_size`](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size).
 * `OVERPASS_USE_AREAS` - if `false` initial area generation and the area updater process will be disabled. Default `true`.
 * `OVERPASS_HEALTHCHECK` - shell commands to execute to verify that image is healthy. `exit 1` in case of failures, `exit 0` when container is healthy. Default healthcheck queries overpass and verifies that there is reponse returned
 * `OVERPASS_STOP_AFTER_INIT` - if `false` the container will keep runing after init is complete. Otherwise container will be stopped after initialization process is complete. Default `true`

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,7 +10,7 @@ OVERPASS_CLONE_SOURCE=${OVERPASS_CLONE_SOURCE:-https://dev.overpass-api.de/api_d
 
 # this is used by other processes, so needs to be exported
 export OVERPASS_MAX_TIMEOUT=${OVERPASS_MAX_TIMEOUT:-1000s}
-export OVERPASS_MAX_SIZE=${OVERPASS_MAX_SIZE:-10M}
+export OVERPASS_MAX_SIZE=${OVERPASS_MAX_SIZE:-1M}
 
 if [[ "$OVERPASS_META" == "attic" ]]; then
 	META="--keep-attic"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -128,7 +128,7 @@ if [[ ! -f /db/init_done ]]; then
 fi
 
 # shellcheck disable=SC2016 # ignore SC2016 (variables within single quotes) as this is exactly what we want to do here
-envsubst '${OVERPASS_MAX_TIMEOUT}' </etc/nginx/nginx.conf.template >/etc/nginx/nginx.conf
+envsubst '${OVERPASS_MAX_TIMEOUT} ${OVERPASS_MAX_SIZE}' </etc/nginx/nginx.conf.template >/etc/nginx/nginx.conf
 
 echo "Starting supervisord process"
 exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,6 +10,7 @@ OVERPASS_CLONE_SOURCE=${OVERPASS_CLONE_SOURCE:-https://dev.overpass-api.de/api_d
 
 # this is used by other processes, so needs to be exported
 export OVERPASS_MAX_TIMEOUT=${OVERPASS_MAX_TIMEOUT:-1000s}
+export OVERPASS_MAX_SIZE=${OVERPASS_MAX_SIZE:-10M}
 
 if [[ "$OVERPASS_META" == "attic" ]]; then
 	META="--keep-attic"

--- a/etc/nginx-overpass.conf.template
+++ b/etc/nginx-overpass.conf.template
@@ -31,8 +31,6 @@ http {
     gzip_proxied any;
     gzip_types *;
 
-    client_max_body_size 10M;
-
 	server {
 		listen       80;
 		server_name  localhost;
@@ -60,6 +58,8 @@ http {
             fastcgi_pass   unix:/nginx/fcgiwrap.socket;
             fastcgi_read_timeout ${OVERPASS_MAX_TIMEOUT};
             fastcgi_send_timeout ${OVERPASS_MAX_TIMEOUT};
+
+            client_max_body_size ${OVERPASS_MAX_SIZE};
 		}
 
 		location /api/ {

--- a/etc/nginx-overpass.conf.template
+++ b/etc/nginx-overpass.conf.template
@@ -31,6 +31,8 @@ http {
     gzip_proxied any;
     gzip_types *;
 
+    client_max_body_size 10M;
+
 	server {
 		listen       80;
 		server_name  localhost;


### PR DESCRIPTION
I have been recieving this error for some large overpass API requests. nginx defaults to a `1M` max request which can be exceeded by some requests.

```
File "/usr/local/lib/python3.12/dist-packages/osmnx/_http.py", line 320, in _parse_response
raise ResponseStatusCodeError(msg) from e
osmnx._errors.ResponseStatusCodeError: '127.0.0.1' responded: 413 Request Entity Too Large <html>
```